### PR TITLE
Server-side add meal

### DIFF
--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/model/Meal.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/model/Meal.java
@@ -38,6 +38,9 @@ public class Meal {
      * rather than a null list in itself.
      */
     public Meal(List<Ingredient> ingredients, String name, String description) {
+        if (ingredients == null) {
+            ingredients = new ArrayList<>();
+        }
         this.ingredients = new ArrayList<>(ingredients);
         this.name = name;
         this.description = description;

--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/model/SystemInfo.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/model/SystemInfo.java
@@ -11,6 +11,7 @@ package edu.westga.cs3212.mealplanner.model;
 public class SystemInfo {
     private static User loggedInUser;
     private static Planner currentPlanner;
+    private static int id;
 
     /**
      * Gets the currently logged in user.
@@ -28,5 +29,23 @@ public class SystemInfo {
      */
     public static void setLoggedInUser(User loggedInUser) {
         SystemInfo.loggedInUser = loggedInUser;
+    }
+
+    /**
+     * Gets the current session id.
+     *
+     * @return The id associated with the current user session.
+     */
+    public static int getId() {
+        return id;
+    }
+
+    /**
+     * Sets the current session id.
+     *
+     * @param id id to associate the current session with.
+     */
+    public static void setId(int id) {
+        SystemInfo.id = id;
     }
 }

--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/view/LandingPageCodeBehind.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/view/LandingPageCodeBehind.java
@@ -21,6 +21,7 @@ public class LandingPageCodeBehind {
     @FXML
     void handleLogOut(ActionEvent event) {
         SystemInfo.setLoggedInUser(null);
+        SystemInfo.setId(-1);
         Main.getMainStage().setTitle(Main.LOGIN_TITLE);
         new SwitchScene(this.landingPane, Main.LOGIN_FXML);
     }

--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Meal adder view model.
@@ -109,11 +110,14 @@ public class AddMealViewModel {
             SystemInfo.getLoggedInUser().getUserPlanner().addMeal(plannedTime, toAdd);
             String serializedMeal = toAdd.serialize();
             HashMap<String, Object> message = new HashMap<>();
-            message.put("reqtype", "ADD_MEAL");
+            message.put("reqtype", "ADD MEAL");
             message.put("meal", serializedMeal);
             message.put("time", plannedTime);
-            message.put("mealtype", selectedMealType);
-            Messenger.request(message);
+            message.put("id", SystemInfo.getId());
+            Map<String, Object> response = Messenger.request(message);
+            if (!response.get("restype").equals("VALID")) {
+                System.out.println(response.get("restype"));
+            }
             this.resetIngredients();
             return toAdd;
         }

--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
@@ -9,9 +9,11 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.scene.control.SingleSelectionModel;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -107,12 +109,14 @@ public class AddMealViewModel {
             var selectedMealType = this.selectedMealType.get();
             var mealHour = new ArrayList<MealType>(List.of(MealType.values())).indexOf(selectedMealType);
             var plannedTime = this.currDate.atTime(mealHour, 0);
+            LocalDateTime truncatedDate = plannedTime.truncatedTo(ChronoUnit.HOURS);
+            long epochHour = truncatedDate.toEpochSecond(ZoneOffset.UTC);
             SystemInfo.getLoggedInUser().getUserPlanner().addMeal(plannedTime, toAdd);
             String serializedMeal = toAdd.serialize();
             HashMap<String, Object> message = new HashMap<>();
             message.put("reqtype", "ADD MEAL");
             message.put("meal", serializedMeal);
-            message.put("time", plannedTime);
+            message.put("time", epochHour);
             message.put("id", SystemInfo.getId());
             Map<String, Object> response = Messenger.request(message);
             if (!response.get("restype").equals("VALID")) {

--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
@@ -119,7 +119,6 @@ public class AddMealViewModel {
             message.put("meal", serializedMeal);
             message.put("time", epochHour);
             message.put("id", SystemInfo.getId());
-            System.out.println(serializedMeal);
             Map<String, Object> response = Messenger.request(message);
             if (response.get("restype").equals("VALID")) {
                 SystemInfo.getLoggedInUser().getUserPlanner().addMeal(plannedTime, toAdd);

--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/AddMealViewModel.java
@@ -99,7 +99,8 @@ public class AddMealViewModel {
      * Creates a meal using the stored ingredients, and a given name/description, and adds it to the current planner.
      * @param name Name of the new meal (if given)
      * @param desc Description of the new meal (if given)
-     * @return The meal that was created, or null if the meal was failed to be added (no ingredients were provided)
+     * @return The meal that was created, or null if the meal was failed to be added.
+     * Fails on either making a meal with no ingredients, or if an error occurs when passing to the server.
      */
     public Meal addMeal(String name, String desc) {
         if (this.plannedIngredients.isEmpty()) {
@@ -111,19 +112,21 @@ public class AddMealViewModel {
             var plannedTime = this.currDate.atTime(mealHour, 0);
             LocalDateTime truncatedDate = plannedTime.truncatedTo(ChronoUnit.HOURS);
             long epochHour = truncatedDate.toEpochSecond(ZoneOffset.UTC);
-            SystemInfo.getLoggedInUser().getUserPlanner().addMeal(plannedTime, toAdd);
+
             String serializedMeal = toAdd.serialize();
             HashMap<String, Object> message = new HashMap<>();
             message.put("reqtype", "ADD MEAL");
             message.put("meal", serializedMeal);
             message.put("time", epochHour);
             message.put("id", SystemInfo.getId());
+            System.out.println(serializedMeal);
             Map<String, Object> response = Messenger.request(message);
-            if (!response.get("restype").equals("VALID")) {
-                System.out.println(response.get("restype"));
+            if (response.get("restype").equals("VALID")) {
+                SystemInfo.getLoggedInUser().getUserPlanner().addMeal(plannedTime, toAdd);
+                this.resetIngredients();
+                return toAdd;
             }
-            this.resetIngredients();
-            return toAdd;
+            return null;
         }
     }
 

--- a/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/LoginViewModel.java
+++ b/MealPlanner/code/MealPlanner/src/main/java/edu/westga/cs3212/mealplanner/viewmodel/LoginViewModel.java
@@ -114,6 +114,7 @@ public class LoginViewModel {
         } else {
             User loggedInUser = new User(this.usernameProperty.get(), this.passwordProperty.get());
             SystemInfo.setLoggedInUser(loggedInUser);
+            SystemInfo.setId((Integer) response.get("id"));
             return true;
         }
     }

--- a/MealPlanner/code/PythonServer/Server/Dispatcher.py
+++ b/MealPlanner/code/PythonServer/Server/Dispatcher.py
@@ -5,6 +5,7 @@ from Server.Data.AuthenticatedUsers import AuthenticatedUsers
 from Server.Enums.Communication import Communication
 from Server.Handlers import LogoutHandler
 from Server.Enums.MessageKey import MessageKey
+from Server.Handlers.AddMealHandler import AddMealHandler
 from Server.Handlers.CreateAccountHandler import CreateAccountHandler
 from Server.Handlers.Handler import Handler
 from Server.Handlers.LoginHandler import LoginHandler
@@ -62,4 +63,4 @@ class Dispatcher:
 
     @staticmethod
     def _handlerNeedsActiveSessions(handler: Handler):
-        return isinstance(handler, (LoginHandler, LogoutHandler))
+        return isinstance(handler, (LoginHandler, LogoutHandler, AddMealHandler))

--- a/MealPlanner/code/PythonServer/Server/Enums/CommunicationType.py
+++ b/MealPlanner/code/PythonServer/Server/Enums/CommunicationType.py
@@ -6,3 +6,4 @@ class CommunicationType(str, Enum):
     GET_USER = "GET USER"
     CREATE_ACCOUNT = "CREATE ACCOUNT"
     GET_PLANNER = "GET PLANNER"
+    ADD_MEAL = "ADD MEAL"

--- a/MealPlanner/code/PythonServer/Server/Enums/MessageKey.py
+++ b/MealPlanner/code/PythonServer/Server/Enums/MessageKey.py
@@ -6,3 +6,5 @@ class MessageKey(str, Enum):
     ID = "id"
     AUTHENTICATED_USERS = "authUsers"
     SESSIONS = "sessions"
+    MEAL = "meal"
+    TIME = "time"

--- a/MealPlanner/code/PythonServer/Server/Handlers/AddMealHandler.py
+++ b/MealPlanner/code/PythonServer/Server/Handlers/AddMealHandler.py
@@ -1,0 +1,50 @@
+from typing import Dict
+
+from Server.Enums.Communication import Communication
+from Server.Enums.CommunicationType import CommunicationType
+from Server.Enums.MessageKey import MessageKey
+from Server.Handlers.Handler import Handler
+
+
+class AddMealHandler(Handler):
+    """
+    Handler for adding a meal to a given planner.
+    """
+    def __init__(self):
+        self.reqtype = CommunicationType.ADD_MEAL
+
+    def handle(self, message):
+        """
+        Adds a meal to a planner, based on the request details.
+
+        :param message: The message to handle.
+        Should contain a serialized Meal, an epoch time to add it to, and the planner ID
+        to add to.
+        :return: Response indicating if the request passed through correctly.
+        """
+        response = dict()
+        if not isinstance(message, Dict):
+            response[Communication.RESPONSE] = "BAD_INPUT"
+            return response
+        if MessageKey.SESSIONS not in message:
+            response[Communication.RESPONSE] = "SYSTEM_ERROR"
+            return response
+        if MessageKey.ID not in message:
+            response[Communication.RESPONSE] = "BAD INPUT"
+            return response
+        if MessageKey.TIME not in message:
+            response[Communication.RESPONSE] = "BAD INPUT"
+            return response
+        if MessageKey.MEAL not in message:
+            response[Communication.RESPONSE] = "BAD INPUT"
+            return response
+        response[Communication.RESPONSE] = "INVALID"
+        activeSessions: dict[int, object] = message.get(MessageKey.SESSIONS)
+        userID = message.get(MessageKey.ID)
+        user = activeSessions.get(userID)
+        userPlanner = user.userPlanner if (user is not None) else None
+
+        if userPlanner is not None:
+            print(message.get(MessageKey.MEAL))
+            response[Communication.RESPONSE] = "VALID"
+        return response

--- a/MealPlanner/code/PythonServer/Server/Handlers/AddMealHandler.py
+++ b/MealPlanner/code/PythonServer/Server/Handlers/AddMealHandler.py
@@ -12,6 +12,7 @@ class AddMealHandler(Handler):
     """
     Handler for adding a meal to a given planner.
     """
+
     def __init__(self):
         self.reqtype = CommunicationType.ADD_MEAL
 
@@ -20,7 +21,7 @@ class AddMealHandler(Handler):
         Adds a meal to a planner, based on the request details.
 
         :param message: The message to handle.
-        Should contain a serialized Meal, an epoch time to add it to, and the planner ID
+        Should contain a serialized Meal, an epoch time to add it to (converted to an int), and the planner ID
         to add to.
         :return: Response indicating if the request passed through correctly.
         """
@@ -31,14 +32,14 @@ class AddMealHandler(Handler):
         if MessageKey.SESSIONS not in message:
             response[Communication.RESPONSE] = "SYSTEM_ERROR"
             return response
-        if MessageKey.ID not in message:
-            response[Communication.RESPONSE] = "BAD INPUT"
+        if MessageKey.ID not in message or not isinstance(message.get(MessageKey.ID), int):
+            response[Communication.RESPONSE] = "BAD_INPUT"
             return response
-        if MessageKey.TIME not in message:
-            response[Communication.RESPONSE] = "BAD INPUT"
+        if MessageKey.TIME not in message or not isinstance(message.get(MessageKey.TIME), int):
+            response[Communication.RESPONSE] = "BAD_INPUT"
             return response
         if MessageKey.MEAL not in message:
-            response[Communication.RESPONSE] = "BAD INPUT"
+            response[Communication.RESPONSE] = "BAD_INPUT"
             return response
         response[Communication.RESPONSE] = "INVALID"
         activeSessions: dict[int, object] = message.get(MessageKey.SESSIONS)

--- a/MealPlanner/code/PythonServer/Server/Handlers/AddMealHandler.py
+++ b/MealPlanner/code/PythonServer/Server/Handlers/AddMealHandler.py
@@ -1,10 +1,12 @@
 from typing import Dict
 
+from Server.Data.Ingredient import Ingredient
+from Server.Data.Meal import Meal
 from Server.Enums.Communication import Communication
 from Server.Enums.CommunicationType import CommunicationType
 from Server.Enums.MessageKey import MessageKey
 from Server.Handlers.Handler import Handler
-
+import json
 
 class AddMealHandler(Handler):
     """
@@ -45,6 +47,13 @@ class AddMealHandler(Handler):
         userPlanner = user.userPlanner if (user is not None) else None
 
         if userPlanner is not None:
-            print(message.get(MessageKey.MEAL))
+            meal = json.loads(message.get(MessageKey.MEAL))
+            timeToAdd = message.get(MessageKey.TIME)
+            ingredients = list()
+            for currIng in meal.get("ingredients"):
+                addedIng = Ingredient(currIng.get("name"), currIng.get("calories"))
+                ingredients.append(addedIng)
+            addedMeal = Meal(ingredients, meal.get("name"), meal.get("description"))
+            userPlanner.addMeal(timeToAdd, addedMeal)
             response[Communication.RESPONSE] = "VALID"
         return response

--- a/MealPlanner/code/PythonServer/Server/main.py
+++ b/MealPlanner/code/PythonServer/Server/main.py
@@ -5,6 +5,7 @@ import json
 
 from Server.Dispatcher import Dispatcher
 from Server.Enums.Communication import Communication
+from Server.Handlers.AddMealHandler import AddMealHandler
 from Server.Handlers.CreateAccountHandler import CreateAccountHandler
 from Server.Handlers.GetPlannerHandler import GetPlannerHandler
 from Server.Handlers.LoginHandler import LoginHandler
@@ -17,12 +18,14 @@ def main():
     message_dispatcher = Dispatcher()
     login_handler = LoginHandler()
     create_account_handler = CreateAccountHandler()
+    add_meal_handler = AddMealHandler()
     message_dispatcher.add(login_handler)
     message_dispatcher.add(LoginHandler())
     message_dispatcher.add(LogoutHandler())
     message_dispatcher.add(GetPlannerHandler())
     message_dispatcher.add(create_account_handler)
     message_dispatcher.add(CreateAccountHandler())
+    message_dispatcher.add(add_meal_handler)
     context = zmq.Context()
     socket = context.socket(zmq.REP)
     socket.bind("tcp://127.0.0.1:5555")

--- a/MealPlanner/code/PythonServer/Test/AddMealHandler/test_add_meal_handle.py
+++ b/MealPlanner/code/PythonServer/Test/AddMealHandler/test_add_meal_handle.py
@@ -1,11 +1,8 @@
 import unittest
 import json
-from Server.Data.Ingredient import Ingredient
-from Server.Data.Meal import Meal
 from Server.Data.User import User
 from Server.Enums.Communication import Communication
 from Server.Handlers.AddMealHandler import AddMealHandler
-from Server.Handlers.LogoutHandler import LogoutHandler
 
 class TestHandle(unittest.TestCase):
     def test_message_not_dict(self):

--- a/MealPlanner/code/PythonServer/Test/AddMealHandler/test_add_meal_handle.py
+++ b/MealPlanner/code/PythonServer/Test/AddMealHandler/test_add_meal_handle.py
@@ -1,0 +1,118 @@
+import unittest
+import json
+from Server.Data.Ingredient import Ingredient
+from Server.Data.Meal import Meal
+from Server.Data.User import User
+from Server.Enums.Communication import Communication
+from Server.Handlers.AddMealHandler import AddMealHandler
+from Server.Handlers.LogoutHandler import LogoutHandler
+
+class TestHandle(unittest.TestCase):
+    def test_message_not_dict(self):
+        handle = AddMealHandler()
+        message = "wrong data"
+        response = handle.handle(message)
+        self.assertEqual("BAD_INPUT", response[Communication.RESPONSE])
+
+    def test_message_lacks_id(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["sessions"] = sessions
+        message["meal"] = json.dumps({"ingredients":[{"name":"Milk","calories":40.0},{"name":"Tomato","calories":60.0},{"name":"Beef","calories":250.0}],"name":"Test Meal","description":"desc"})
+        message["time"] = 100019
+        response = handle.handle(message)
+        self.assertEqual("BAD_INPUT", response[Communication.RESPONSE])
+
+    def test_message_id_is_not_int(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["id"] = "10"
+        message["sessions"] = sessions
+        message["meal"] = json.dumps({"ingredients":[{"name":"Milk","calories":40.0},{"name":"Tomato","calories":60.0},{"name":"Beef","calories":250.0}],"name":"Test Meal","description":"desc"})
+        message["time"] = 100019
+        response = handle.handle(message)
+        self.assertEqual("BAD_INPUT", response[Communication.RESPONSE])
+
+    def test_message_lacks_sessions(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["id"] = 10
+        message["meal"] = json.dumps({"ingredients":[{"name":"Milk","calories":40.0},{"name":"Tomato","calories":60.0},{"name":"Beef","calories":250.0}],"name":"Test Meal","description":"desc"})
+        message["time"] = 100019
+        response = handle.handle(message)
+        self.assertEqual("SYSTEM_ERROR", response[Communication.RESPONSE])
+
+    def test_message_lacks_time(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["sessions"] = sessions
+        message["id"] = 10
+        message["meal"] = json.dumps({"ingredients":[{"name":"Milk","calories":40.0},{"name":"Tomato","calories":60.0},{"name":"Beef","calories":250.0}],"name":"Test Meal","description":"desc"})
+        response = handle.handle(message)
+        self.assertEqual("BAD_INPUT", response[Communication.RESPONSE])
+
+    def test_message_time_is_not_int(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["sessions"] = sessions
+        message["id"] = 10
+        message["meal"] = json.dumps({"ingredients":[{"name":"Milk","calories":40.0},{"name":"Tomato","calories":60.0},{"name":"Beef","calories":250.0}],"name":"Test Meal","description":"desc"})
+        message["time"] = "99818211"
+        response = handle.handle(message)
+        self.assertEqual("BAD_INPUT", response[Communication.RESPONSE])
+
+    def test_message_lacks_meal(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["sessions"] = sessions
+        message["id"] = 10
+        message["time"] = "99818211"
+        response = handle.handle(message)
+        self.assertEqual("BAD_INPUT", response[Communication.RESPONSE])
+
+    def test_no_value_of_id(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["sessions"] = sessions
+        message["id"] = 7
+        message["meal"] = json.dumps({"ingredients":[{"name":"Milk","calories":40.0},{"name":"Tomato","calories":60.0},{"name":"Beef","calories":250.0}],"name":"Test Meal","description":"desc"})
+        message["time"] = 100019
+        response = handle.handle(message)
+        self.assertEqual("INVALID", response[Communication.RESPONSE])
+
+    def test_correct_input(self):
+        handle = AddMealHandler()
+        message = dict()
+        inputUser = User("username", "password")
+        sessions = dict()
+        sessions[10] = inputUser
+        message["sessions"] = sessions
+        message["id"] = 10
+        message["meal"] = json.dumps({"ingredients":[{"name":"Milk","calories":40.0},{"name":"Tomato","calories":60.0},{"name":"Beef","calories":250.0}],"name":"Test Meal","description":"desc"})
+        message["time"] = 99818211
+        response = handle.handle(message)
+        self.assertEqual("VALID", response[Communication.RESPONSE])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/MealPlanner/code/PythonServer/Test/AddMealHandler/test_constructor.py
+++ b/MealPlanner/code/PythonServer/Test/AddMealHandler/test_constructor.py
@@ -1,0 +1,12 @@
+import unittest
+
+from Server.Handlers.AddMealHandler import AddMealHandler
+
+class TestConstructor(unittest.TestCase):
+    def test_constructor(self):
+        handle = AddMealHandler()
+        self.assertEqual("ADD MEAL", handle.reqtype)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/MealPlanner/code/PythonServer/Test/LogoutHandler/test_handle.py
+++ b/MealPlanner/code/PythonServer/Test/LogoutHandler/test_handle.py
@@ -1,6 +1,5 @@
 import unittest
 
-from Server.Data.AuthenticatedUsers import AuthenticatedUsers
 from Server.Data.User import User
 from Server.Enums.Communication import Communication
 from Server.Handlers.LogoutHandler import LogoutHandler


### PR DESCRIPTION
ID is stored on login, and set to -1 as a placeholder on logging out.
Time is converted to the long variant in the planner add method when it is passed to the server.

A couple of the client-side addMeal tests are broken. I am not sure how to fix them.
Otherwise, should be working.

Closes: #34 